### PR TITLE
Migrate to conversations api

### DIFF
--- a/chat_bot_command.rb
+++ b/chat_bot_command.rb
@@ -134,14 +134,13 @@ module ChatBotCommand
   def ChatBotCommand.slack_api(method, args)
     api = "https://slack.com/api/" + method
     uri = URI.parse(api)
-
-    args["token"] = $SETTINGS["SLACK_API_TOKEN"]
     uri.query = URI.encode_www_form(args)
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
 
     request = Net::HTTP::Get.new(uri.request_uri)
+    request["Authorization"] = "Bearer " + $SETTINGS["SLACK_API_TOKEN"]
     response = http.request(request)
 
     if response.code == "200"

--- a/chat_bot_command.rb
+++ b/chat_bot_command.rb
@@ -106,9 +106,9 @@ module ChatBotCommand
   def ChatBotCommand.get_channel_list
     channels = {}
     args = {
-      cursor: "",
-      limit: 1000,
-      types: "public_channel,private_channel,mpim"
+      "cursor" => "",
+      "limit" => 1000,
+      "types" => "public_channel,private_channel"
     }
 
     loop do
@@ -121,8 +121,8 @@ module ChatBotCommand
       end
 
       next_cursor = response["response_metadata"]["next_cursor"]
-      args[:cursor] = next_cursor
       break if next_cursor.empty?
+      args["cursor"] = next_cursor
     end
 
     return channels.empty? ? nil : channels


### PR DESCRIPTION
`channels.*`, `im.*`, `mpim.*`, and `groups.*` methods will be deprecated in favor of `conversations.*`